### PR TITLE
Run pytest when PR is made

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Run tests
+
+on:
+  pull_request:
+
+jobs:
+  run_tests:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v3
+
+    - name: Set up rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Set up rust cache
+      uses: Swatinem/rust-cache@v2
+
+    - name: Set up python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Install nbstripout-fast
+      run: |
+        pip install .[test]
+
+    - name: Run tests
+      run: |
+        pytest ./

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,17 +18,13 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Set up rust cache
       uses: Swatinem/rust-cache@v2
 
     - name: Set up python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.11'
 
@@ -45,7 +41,7 @@ jobs:
         twine check wheelhouse/*
 
     - name: Upload sdist
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: wheels
         path: ./wheelhouse/*.tar.gz

--- a/README.md
+++ b/README.md
@@ -73,16 +73,22 @@ RUST_LOG=debug cargo run -- '--extra-keys "metadata.bar cell.baz" -t foo.ipynb'
 ```
 
 ## Releasing
-We release only the bin version (i.e. just the CLI). The release
-builds wheels for manylinux. Before doing this, update the version in
-`Cargo.toml`
-```
+
+Manylinux, macos, and windows wheels and sdist are built by github workflows.
+Builds are triggered upon the creation of a pull request, creating a new
+release, or with a manual workflow dispatch. The wheels and sdist are only
+uploaded to PyPI when a new release is published. In order to create a new
+release:
+
+1. Create a commit updating the version in `Cargo.toml`, then create a git tag:
+```bash
 git tag vX.Y.Z
 git push --tags
-
-maturin build -b bin --sdist
-twine upload -r target/wheels/*
 ```
+2. Draft a new release in github; select the tag that you just created.
+3. Once the new release is created, the wheels and sdist will be built by a
+   github workflow and then uploaded to PyPI automatically using the
+   `PYPI_API_TOKEN` in the github secrets for the repository.
 
 ## History
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,11 @@ classifiers=[
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "nbformat",
+    "nbconvert",
+    "ipykernel",
+]


### PR DESCRIPTION
## Summary

This PR defines a pytest job which runs when a PR is made.

## Changes

- Added new `run_tests` job to run pytest
- Added optional dependencies for the test environment. May not be complete!
- Swapped out `actions-rs/toolchain` for `dtolnay/rust-toolchain` which is more actively maintained; this addresses a deprecation warning.
- Bumped the versions of `actions/upload-artifact` and `actions/setup-python` to address a different deprecation warning.