### PR TITLE
Add CLI binary installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,19 @@ jobs:
       with:
         python-version: '3.11'
 
-    - name: Install nbstripout-fast
+    - name: Install python dependencies
       run: |
-        pip install .[test]
+        pip install maturin
+        pip install pytest nbformat nbconvert ipykernel
+
+    # Build pyo3 bindings manually, then install with
+    # pip; can't pass args directly through to pip.
+    # Also, maturin can't set the output wheel name, so
+    # we need to find it directly.
+    - name: Install python bindings for nbstripout-fast
+      run: |
+        maturin build -b pyo3 --out wheel
+        pip install $(find ./wheel -name '*.whl' | head -n 1)
 
     - name: Run tests
       run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -107,7 +107,7 @@ jobs:
         CIBW_SKIP: '*-musllinux_i686'
         # we build for matrix.arch (only exists on macos), else 'auto'
         CIBW_ARCHS: ${{ matrix.arch || 'auto' }}
-        CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH" CARGO_TERM_COLOR="always"'
+        CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH" CARGO_TERM_COLOR="always" MATURIN_PEP517_ARGS="--no-default-features"'
         CIBW_ENVIRONMENT_WINDOWS: 'PATH="$UserProfile\.cargo\bin;$PATH"'
         CIBW_BEFORE_BUILD: rustup show
         # Linux wheels are built in manylinux containers; set up rust toolchain here

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos, windows]
+        os: [ubuntu, windows]
         python-version: ['cp311', 'cp310', 'cp39']
         include:
           - os: ubuntu
@@ -62,9 +62,6 @@ jobs:
           - os: windows
             ls: dir
             pip_cache: ~\AppData\Local\pip\Cache
-          - os: macos
-            arch: 'arm64 universal2'
-            pip_cache: ~/Library/Caches/pip
 
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ serde_yaml = "0.8"
 clap = { version = "3.0", features = ["derive"] }
 log = "0.4.0"
 env_logger = "0.8.4"
+
+[features]
+default = ["extension-module"]
+extension-module = ["pyo3/extension-module"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ url="https://github.com/deshaw/nbstripout-fast"
 requires_python=">=3.9"
 setup_requires=[
     "pytest-runner",
-    "setuptools >= 30"
 ]
 tests_require=[
     "nbformat",
@@ -39,3 +38,6 @@ test = [
     "nbconvert",
     "ipykernel",
 ]
+
+[tool.maturin]
+bindings = "bin"


### PR DESCRIPTION
This PR adds a configuration setting to install the rust nbstripout-fast CLI to the python binary directory, so that users can easily launch the CLI after installing.