### PR TITLE
Fix path to wheels/sdist encountered during publish to PyPI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -133,6 +133,8 @@ jobs:
     steps:
       - name: Retrieve wheels and sdist
         uses: actions/download-artifact@v3
+        with:
+          path: dist
 
       - name: Upload to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1.5

--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,4 @@ Cargo.lock
 *.pdb
 
 # End of https://www.toptal.com/developers/gitignore/api/python,rust
+.python-version


### PR DESCRIPTION
This PR fixes an issue where the path to the wheels to be uploaded to PyPI during a release could not be found.