### PR TITLE
Fix issue where publish action didn't point to the right directory

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -69,17 +69,13 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.11'
 
     - if: matrix.os == 'macos' || matrix.os == 'windows'
       name: Set up rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
 
     - if: matrix.os == 'macos' || matrix.os == 'windows'
       name: Set up rust cache
@@ -89,9 +85,11 @@ jobs:
 
     # Set up rust toolchain on mac os and windows (linux containers handled below)
     - if: matrix.os == 'macos'
+      name: Add aarch64-apple-darwin target
       run: rustup target add aarch64-apple-darwin
 
     - if: matrix.os == 'windows'
+      name: Add i686-pc-windows-msvc target
       run: |
         rustup toolchain install stable-i686-pc-windows-msvc
         rustup target add i686-pc-windows-msvc
@@ -128,15 +126,18 @@ jobs:
   upload_to_pypi:
     name: Upload to PYPI
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
+    if: (github.event_name == 'release' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch')
     needs: [build_wheels, build_sdist]
     steps:
       - name: Retrieve wheels and sdist
         uses: actions/download-artifact@v3
-        with:
-          path: dist
+
+      - name: List the build artifacts
+        run: |
+          ls -lAs wheels/
 
       - name: Upload to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1.5
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: wheels/


### PR DESCRIPTION
During the `upload_to_pypi` stage, retrieving the artifacts that were built during the previous stages were accidentally nested inside the `dist/wheels/` directory. This PR removes that nesting, so the `download-artifact` action now downloads the wheels to `wheels/*{.whl,.tar.gz}`. Finally, the `gh-action-pypi-publish` action now points to the `wheels/` directory, and correctly finds the artifacts inside. See https://github.com/peytondmurray/nbstripout-fast/actions/runs/3634458847 for a successful run (except there's no secret defined on my fork, so the upload doesn't work.)

Other changes:
- Made release manually triggerable
- Use `dtolnay/rust-toolchain@stable` instead of `actions-rs` because it works with github's new workflow syntax, meaning that we won't get more deprecation warnings
- Update a place where I missed `setup-python` to v4 to avoid another warning
- Artifacts that are being uploaded to PyPI are first listed to aid future workflow maintainers