### PR TITLE
Suppress maturin version warning and unused function warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.13,<0.14"]
+requires = ["maturin>=1.4"]
 build-backend = "maturin"
 
 [project]

--- a/src/stripoutlib.rs
+++ b/src/stripoutlib.rs
@@ -62,6 +62,7 @@ fn determine_keep_output(cell: &JSONMap, default: bool) -> Result<bool, String> 
 }
 
 // TODO: add custom errors instead of returning a string
+#[cfg_attr(not(feature = "extension-module"), allow(unused))]
 pub fn strip_output(
     nb: &mut serde_json::Value,
     keep_output: bool,


### PR DESCRIPTION
This PR updates the required maturin version to 1.4, and conditionally adds an `allow(unused)` attribute to strip_output if we are building a binary (currently we only only build python bindings for testing purposes).