### PR TITLE
Update the pypa/gh-action-pypi-publish action version

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -129,6 +129,11 @@ jobs:
     runs-on: ubuntu-latest
     if: (github.event_name == 'release' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch')
     needs: [build_wheels, build_sdist]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/nbstripout-fast
+    permissions:
+      id-token: write
     steps:
       - name: Retrieve wheels and sdist
         uses: actions/download-artifact@v3
@@ -138,7 +143,6 @@ jobs:
           ls -lAs wheels/
 
       - name: Upload to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.5
+        uses: pypa/gh-action-pypi-publish@release/v1.8
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: wheels/


### PR DESCRIPTION
This PR updates the `pypa/gh-action-pypi-publish` version. After checking the requirements for this action, it looks like this uses `pkginfo==1.10.0`, potentially solving the issue we're seeing.

It's also been a while since a version was released, and trusted publishing now requires different permissions for the publish job. See https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing for more information on this configuration; without it, I tried testing publishing releases to test.pypi.org and they failed.

@mlucool I don't have the permissions needed to edit trusted publishers on the PYPI project page, but it should be pretty easy to do so by following these instructions before attempting to make a new release: https://docs.pypi.org/trusted-publishers/adding-a-publisher/.

Alternatively if you'd prefer that I take care of it, add me to the project and I can do the trusted publishing setup.

A side effect of this PR is that we can now get rid of the PYPI_API_TOKEN secret.