### PR TITLE
Bump github actions versions to silence node version warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up rust toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -18,7 +18,7 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up rust toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -24,7 +24,7 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
 
@@ -41,9 +41,9 @@ jobs:
         twine check wheelhouse/*
 
     - name: Upload sdist
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-sdist
         path: ./wheelhouse/*.tar.gz
 
   build_wheels:
@@ -66,10 +66,10 @@ jobs:
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
 
@@ -119,9 +119,9 @@ jobs:
         twine check wheelhouse/*
 
     - name: Upload wheels
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-${{ matrix.os }}-${{ matrix.python-version }}
         path: ./wheelhouse/*.whl
 
   upload_to_pypi:
@@ -136,7 +136,11 @@ jobs:
       id-token: write
     steps:
       - name: Retrieve wheels and sdist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: wheels/
 
       - name: List the build artifacts
         run: |


### PR DESCRIPTION
This PR bumps the github action versions, which silences Node 16 deprecation warnings. The new version of `actions/upload-artifact` doesn't allow multiple artifacts to be uploaded to the same target, so there are a few changes I made in accordance with https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md to get this to work.