### PR TITLE
[ENH] Add ability to strip output via regex

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install python dependencies
       run: |
         pip install maturin
-        pip install pytest nbformat nbconvert ipykernel
+        pip install pytest nbformat nbconvert ipykernel ipywidgets
 
     # Build pyo3 bindings manually, then install with
     # pip; can't pass args directly through to pip.

--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,6 @@ Cargo.lock
 
 # End of https://www.toptal.com/developers/gitignore/api/python,rust
 .python-version
+
+# Ignore wheels built by maturin
+wheel/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.0.5](https://github.com/deshaw/nbstripout-fast/compare/v1.0.3...v1.0.4)(2025-06-30)
+### Added
+- Added the ability to specify a regex with `--strip-regex`. Outputs which match
+  this regex will be stripped unconditionally, even if `--keep-output` is
+  specified, allowing users to target specific outputs to remove
+  [#21](https://github.com/deshaw/nbstripout-fast/pull/21)
+
 ## [1.0.4](https://github.com/deshaw/nbstripout-fast/compare/v1.0.3...v1.0.4) (2024-05-03)
 ### Fixed
 - git worktree support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "nbstripout_fast"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pyo3 = { version = "0.16.5", features = ["extension-module"], optional = true }
+pyo3 = { version = "0.25.0", features = ["extension-module"], optional = true }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = {version = "1.0.48",  features = [
   "float_roundtrip",
@@ -19,6 +19,7 @@ serde_yaml = "0.8"
 clap = { version = "3.0", features = ["derive"] }
 log = "0.4.0"
 env_logger = "0.8.4"
+regex = "1.11.1"
 
 [features]
 default = ["extension-module"]

--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ This example illustrates how `nbstripout-fast` can be used to automatically clea
 	git add --renormalize . git commit -m "Cleaned Jupyter notebooks"
 	```
 
+## Stripping specific cell outputs
+
+To strip cell outputs that match a regular expression, the `--strip-regex`
+option can be used in combination with `--keep-output`. For example, to remove
+cell only outputs that include a notebook widget:
+
+```bash
+nbstripout-fast --keep-output --strip-regex "^Output()$"
+```
 
 ## Developing
 You can use cargo which will build + run the CLI:

--- a/README.md
+++ b/README.md
@@ -85,11 +85,20 @@ This example illustrates how `nbstripout-fast` can be used to automatically clea
 
 To strip cell outputs that match a regular expression, the `--strip-regex`
 option can be used in combination with `--keep-output`. For example, to remove
-cell only outputs that include a notebook widget:
+cell outputs that only contain a notebook widget:
 
 ```bash
-nbstripout-fast --keep-output --strip-regex "^Output()$"
+nbstripout-fast --keep-output --strip-regex "^Output\(\)$"
 ```
+
+or to remove completed tqdm progress bars:
+
+```bash
+nbstripout-fast --keep-output --strip-regex "100%.*"
+```
+
+See the [documentation for `regex`](https://docs.rs/regex/latest/regex/) for
+information about supported regex syntax.
 
 ## Developing
 You can use cargo which will build + run the CLI:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ test = [
     "nbformat",
     "nbconvert",
     "ipykernel",
+    "ipywidgets",
 ]
 
 [tool.maturin]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ mod python {
             keep_count,
             &extra_keys,
             drop_empty_cells,
-            &strip_regex.unwrap_or_else(|| "^Output();?$".to_string()),
+            strip_regex.as_deref(),
         )
         .map_err(PyRuntimeError::new_err)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod python {
 
     /// Strips output from a notebook (string) and returns back a notebook (string)
     #[pyfunction]
-    #[pyo3(signature = (contents, keep_output, keep_count, extra_keys, drop_empty_cells, strip_regex = "^Output();?$".to_string()))]
+    #[pyo3(signature = (contents, keep_output, keep_count, extra_keys, drop_empty_cells, strip_regex = None))]
     fn stripout(
         contents: String,
         keep_output: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,14 +10,14 @@ mod python {
 
     /// Strips output from a notebook (string) and returns back a notebook (string)
     #[pyfunction]
-    #[pyo3(signature = (contents, keep_output, keep_count, extra_keys, drop_empty_cells, widget_regex = "^Output();?$".to_string()))]
+    #[pyo3(signature = (contents, keep_output, keep_count, extra_keys, drop_empty_cells, strip_regex = "^Output();?$".to_string()))]
     fn stripout(
         contents: String,
         keep_output: bool,
         keep_count: bool,
         extra_keys: Vec<String>,
         drop_empty_cells: bool,
-        widget_regex: Option<String>,
+        strip_regex: Option<String>,
     ) -> PyResult<String> {
         // If rust ever comes up with a PyObject to serde we should accept a
         // notebook object instead. This is cheap and mostly used for testing
@@ -31,7 +31,7 @@ mod python {
             keep_count,
             &extra_keys,
             drop_empty_cells,
-            &widget_regex.unwrap_or_else(|| "^Output();?$".to_string()),
+            &strip_regex.unwrap_or_else(|| "^Output();?$".to_string()),
         )
         .map_err(PyRuntimeError::new_err)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ mod python {
         keep_count: bool,
         extra_keys: Vec<String>,
         drop_empty_cells: bool,
-        widget_regex: String,
+        widget_regex: Option<String>,
     ) -> PyResult<String> {
         // If rust ever comes up with a PyObject to serde we should accept a
         // notebook object instead. This is cheap and mostly used for testing
@@ -31,7 +31,7 @@ mod python {
             keep_count,
             &extra_keys,
             drop_empty_cells,
-            &widget_regex,
+            &widget_regex.unwrap_or_else(|| "^Output();?$".to_string()),
         )
         .map_err(PyRuntimeError::new_err)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,14 @@ mod python {
 
     /// Strips output from a notebook (string) and returns back a notebook (string)
     #[pyfunction]
+    #[pyo3(signature = (contents, keep_output, keep_count, extra_keys, drop_empty_cells, widget_regex = "^Output();?$".to_string()))]
     fn stripout(
         contents: String,
         keep_output: bool,
         keep_count: bool,
         extra_keys: Vec<String>,
         drop_empty_cells: bool,
+        widget_regex: String,
     ) -> PyResult<String> {
         // If rust ever comes up with a PyObject to serde we should accept a
         // notebook object instead. This is cheap and mostly used for testing
@@ -29,6 +31,7 @@ mod python {
             keep_count,
             &extra_keys,
             drop_empty_cells,
+            &widget_regex,
         )
         .map_err(PyRuntimeError::new_err)?;
 
@@ -41,7 +44,7 @@ mod python {
 
     /// nbstripout, but in rust!
     #[pymodule]
-    fn nbstripout_fast(_py: Python, m: &PyModule) -> PyResult<()> {
+    fn nbstripout_fast(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
         env_logger::init();
 
         m.add_function(wrap_pyfunction!(stripout, m)?)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,9 @@ struct Cli {
     ignore_git_nb_config: bool,
 
     #[clap(long, action)]
-    /// Specify a regex to use to strip matching output
+    /// Specify a regex to use to strip matching output. Even if other settings would keep
+    /// cell output (for example, if `--keep-output` is specified), matching cell outputs will be
+    /// stripped regardless.
     strip_regex: Option<String>,
 
     #[clap(parse(from_os_str))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,8 @@ struct Cli {
     #[clap(long, action)]
     /// Specify a regex to use to strip matching output. Even if other settings would keep
     /// cell output (for example, if `--keep-output` is specified), matching cell outputs will be
-    /// stripped regardless.
+    /// stripped regardless. The regex should adhere to rust's regex dialect; see
+    /// https://docs.rs/regex/latest/regex/ for more information.
     strip_regex: Option<String>,
 
     #[clap(parse(from_os_str))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ fn process_file(
     keep_count: bool,
     extra_keys: &Vec<String>,
     drop_empty_cells: bool,
-    strip_regex: &str,
+    strip_regex: Option<&str>,
     output_file: Option<PathBuf>,
 ) -> Result<(), String> {
     let mut nb: serde_json::Value = serde_json::from_str(&contents)
@@ -196,7 +196,7 @@ fn main() -> Result<(), String> {
     let mut keep_output = false;
     let mut keep_count = false;
     let mut drop_empty_cells = false;
-    let strip_regex = args.widget_regex.unwrap_or("Output()".to_string());
+    let strip_regex = args.strip_regex.as_deref();
 
     let mut extra_keys: Vec<String> = vec![];
     for key in DEFAULT_EXTRA_KEYS {
@@ -272,7 +272,7 @@ fn main() -> Result<(), String> {
             keep_count,
             &extra_keys,
             drop_empty_cells,
-            &strip_regex,
+            strip_regex,
             None,
         )?;
     } else {
@@ -293,7 +293,7 @@ fn main() -> Result<(), String> {
                 keep_count,
                 &extra_keys,
                 drop_empty_cells,
-                &strip_regex,
+                strip_regex,
                 output_file,
             )?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,8 +79,8 @@ struct Cli {
     ignore_git_nb_config: bool,
 
     #[clap(long, action)]
-    /// Specify a regex to use to strip out useless widgets
-    widget_regex: Option<String>,
+    /// Specify a regex to use to strip output that matches the regex
+    strip_regex: Option<String>,
 
     #[clap(parse(from_os_str))]
     /// Files to strip output from
@@ -141,7 +141,7 @@ fn process_file(
     keep_count: bool,
     extra_keys: &Vec<String>,
     drop_empty_cells: bool,
-    widget_regex: &str,
+    strip_regex: &str,
     output_file: Option<PathBuf>,
 ) -> Result<(), String> {
     let mut nb: serde_json::Value = serde_json::from_str(&contents)
@@ -153,7 +153,7 @@ fn process_file(
         keep_count,
         &extra_keys,
         drop_empty_cells,
-        widget_regex,
+        strip_regex,
     )?;
 
     // Format with 1 space to match nbformat
@@ -196,7 +196,7 @@ fn main() -> Result<(), String> {
     let mut keep_output = false;
     let mut keep_count = false;
     let mut drop_empty_cells = false;
-    let widget_regex = args.widget_regex.unwrap_or("Output()".to_string());
+    let strip_regex = args.widget_regex.unwrap_or("Output()".to_string());
 
     let mut extra_keys: Vec<String> = vec![];
     for key in DEFAULT_EXTRA_KEYS {
@@ -272,7 +272,7 @@ fn main() -> Result<(), String> {
             keep_count,
             &extra_keys,
             drop_empty_cells,
-            &widget_regex,
+            &strip_regex,
             None,
         )?;
     } else {
@@ -293,7 +293,7 @@ fn main() -> Result<(), String> {
                 keep_count,
                 &extra_keys,
                 drop_empty_cells,
-                &widget_regex,
+                &strip_regex,
                 output_file,
             )?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ struct Cli {
     ignore_git_nb_config: bool,
 
     #[clap(long, action)]
-    /// Specify a regex to use to strip output that matches the regex
+    /// Specify a regex to use to strip matching output
     strip_regex: Option<String>,
 
     #[clap(parse(from_os_str))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,10 @@ struct Cli {
     /// Ignore settings from .git-nbconfig.yaml
     ignore_git_nb_config: bool,
 
+    #[clap(long, action)]
+    /// Specify a regex to use to strip out useless widgets
+    widget_regex: Option<String>,
+
     #[clap(parse(from_os_str))]
     /// Files to strip output from
     files: Vec<PathBuf>,
@@ -137,6 +141,7 @@ fn process_file(
     keep_count: bool,
     extra_keys: &Vec<String>,
     drop_empty_cells: bool,
+    widget_regex: &str,
     output_file: Option<PathBuf>,
 ) -> Result<(), String> {
     let mut nb: serde_json::Value = serde_json::from_str(&contents)
@@ -148,6 +153,7 @@ fn process_file(
         keep_count,
         &extra_keys,
         drop_empty_cells,
+        widget_regex,
     )?;
 
     // Format with 1 space to match nbformat
@@ -190,6 +196,7 @@ fn main() -> Result<(), String> {
     let mut keep_output = false;
     let mut keep_count = false;
     let mut drop_empty_cells = false;
+    let widget_regex = args.widget_regex.unwrap_or("Output()".to_string());
 
     let mut extra_keys: Vec<String> = vec![];
     for key in DEFAULT_EXTRA_KEYS {
@@ -265,6 +272,7 @@ fn main() -> Result<(), String> {
             keep_count,
             &extra_keys,
             drop_empty_cells,
+            &widget_regex,
             None,
         )?;
     } else {
@@ -285,6 +293,7 @@ fn main() -> Result<(), String> {
                 keep_count,
                 &extra_keys,
                 drop_empty_cells,
+                &widget_regex,
                 output_file,
             )?;
         }

--- a/src/stripoutlib.rs
+++ b/src/stripoutlib.rs
@@ -83,7 +83,7 @@ fn determine_keep_output(cell: &JSONMap, default: bool, strip_regex: Option<&Reg
                 .ok_or("Could not get cell outputs.")?;
 
             for output in outputs {
-                let obj = output.as_object().ok_or("Cell output is not a map; notebook is malformed.")?;
+                let obj = output.as_object().ok_or("Cell output is not a JSON object; notebook is malformed.")?;
                 if output_matches_regex(obj, reg).unwrap_or(false) {
                     // If there's a regex match, that takes precedence over any other
                     // options

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pathlib
+import pytest
+import nbformat
+
+
+@pytest.fixture
+def widget_notebook():
+    with open(pathlib.Path(__file__).parent / 'test_notebook.ipynb') as f:
+        return nbformat.v4.reads(f.read())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,5 +5,9 @@ import nbformat
 
 @pytest.fixture
 def widget_notebook():
+    """A sample notebook containing some widgets and other output.
+
+    Added from https://github.com/deshaw/nbstripout-fast/pull/21.
+    """
     with open(pathlib.Path(__file__).parent / 'test_notebook.ipynb') as f:
         return nbformat.v4.reads(f.read())

--- a/tests/test_nbstripout_fast.py
+++ b/tests/test_nbstripout_fast.py
@@ -202,7 +202,7 @@ def test_no_regex(keep_output):
     """Check that outputs get stripped if no regex is specified."""
     stripped_notebook = _stripout_helper(executed_nb, keep_output=keep_output)
     assert len(executed_nb.cells[-2].outputs) > 0
-    assert len(stripped_notebook.cells[-2].outputs) == 1 if keep_output else 0
+    assert len(stripped_notebook.cells[-2].outputs) == (1 if keep_output else 0)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_nbstripout_fast.py
+++ b/tests/test_nbstripout_fast.py
@@ -205,6 +205,32 @@ def test_no_regex(keep_output):
     assert len(stripped_notebook.cells[-2].outputs) == 1 if keep_output else 0
 
 
-def test_regex_stripped2(widget_notebook):
-    stripped = _stripout_helper(widget_notebook)
-    pass
+@pytest.mark.parametrize(
+    "keep_output",
+    [
+        True,
+        False,
+    ]
+)
+@pytest.mark.parametrize(
+    ("strip_regex", "regex_matches"),
+    [
+        (None, False),
+        (r"Output\(\)", True),
+        (r"Output", True),
+        (r"Output.*", True),
+        (r"what?", False),
+        (r"utput.*", True),
+        (r".*utput.*", True),
+        (r"put*", True),
+        (r".*put.*", True),
+        (r"put\(\)", True),
+        (r"put\(\)$", True),
+        (r"^put\(\)$", False),
+        (r"Output$", False),
+    ]
+)
+def test_regex2(strip_regex, regex_matches, keep_output, widget_notebook):
+    stripped = _stripout_helper(widget_notebook, strip_regex=strip_regex)
+    breakpoint()
+    assert 0

--- a/tests/test_nbstripout_fast.py
+++ b/tests/test_nbstripout_fast.py
@@ -177,7 +177,7 @@ def test_useless_widget_stripped(widget_regex, is_stripped):
 
 
 def test_useless_widget_stripped_no_regex():
-    """Check that useless ipywidget outputs get stripped."""
+    """Check that useless ipywidget outputs get stripped if no regex is specified."""
     stripped_notebook = _stripout_helper(executed_nb)
     assert len(executed_nb.cells[-2].outputs) > 0
     assert len(stripped_notebook.cells[-2].outputs) == 0

--- a/tests/test_nbstripout_fast.py
+++ b/tests/test_nbstripout_fast.py
@@ -33,6 +33,8 @@ def create_notebook():
         nbformat.v4.new_markdown_cell("## A section"),
         nbformat.v4.new_code_cell(""),
         nbformat.v4.new_code_cell("x += 3\nx"),
+        nbformat.v4.new_code_cell("from ipywidgets import Output; o = Output(); o"),
+        nbformat.v4.new_code_cell("with o: print('hi')"),
     ]
     return nb
 
@@ -88,7 +90,7 @@ def test_keep_output():
     assert all(
         cell.get("execution_count", None) is None for cell in stripped_notebook.cells
     )
-    assert len(stripped_notebook.cells[-1]["outputs"]) == 1
+    assert len(stripped_notebook.cells[-3]["outputs"]) == 1
 
 
 def test_keep_count():
@@ -96,14 +98,14 @@ def test_keep_count():
 
     assert all(len(cell.get("outputs", [])) == 0 for cell in stripped_notebook.cells)
     # A bit harder than all as cells without source don't have counts
-    assert stripped_notebook.cells[-1]["execution_count"] == 3
+    assert stripped_notebook.cells[-3]["execution_count"] == 3
 
 
 def test_drop_empty_cells():
     stripped_notebook = _stripout_helper(executed_nb, drop_empty_cells=True)
 
     copied_nb = deepcopy(clean_nb)
-    copied_nb.cells.pop(-2)  # The empty cell
+    copied_nb.cells.pop(-4)  # The empty cell
     copied_nb
     assert copied_nb == stripped_notebook
 
@@ -140,6 +142,13 @@ def test_source_as_strings():
     )
 
     copied_nb = deepcopy(clean_nb)
-    copied_nb.cells.pop(-2)  # The empty cell
+    copied_nb.cells.pop(-4)  # The empty cell
     copied_nb
     assert copied_nb == stripped_notebook
+
+
+def test_useless_widget_stripped():
+    """Check that useless ipywidget outputs get stripped."""
+    stripped_notebook = _stripout_helper(executed_nb)
+    assert len(executed_nb.cells[-2].outputs) > 0
+    assert len(stripped_notebook.cells[-2].outputs) == 0

--- a/tests/test_nbstripout_fast.py
+++ b/tests/test_nbstripout_fast.py
@@ -55,7 +55,7 @@ def _stripout_helper(
     keep_count=False,
     extra_keys=None,
     drop_empty_cells=False,
-    widget_regex=None,
+    strip_regex=None,
 ):
     if extra_keys is None:
         extra_keys = DEFAULT_EXTRA_KEYS
@@ -65,7 +65,7 @@ def _stripout_helper(
         keep_count=keep_count,
         extra_keys=extra_keys,
         drop_empty_cells=drop_empty_cells,
-        widget_regex=widget_regex,
+        strip_regex=strip_regex,
     )
     return nbformat.v4.reads(content)
 
@@ -152,7 +152,7 @@ def test_source_as_strings():
 
 
 @pytest.mark.parametrize(
-    ("widget_regex", "is_stripped"),
+    ("strip_regex", "is_stripped"),
     [
         (None, True),
         ("Output()", True),
@@ -169,9 +169,9 @@ def test_source_as_strings():
         ("Output$", False),
     ]
 )
-def test_useless_widget_stripped(widget_regex, is_stripped):
+def test_useless_widget_stripped(strip_regex, is_stripped):
     """Check that useless ipywidget outputs get stripped."""
-    stripped_notebook = _stripout_helper(executed_nb, widget_regex=widget_regex)
+    stripped_notebook = _stripout_helper(executed_nb, strip_regex=strip_regex)
     assert len(executed_nb.cells[-2].outputs) > 0
     assert len(stripped_notebook.cells[-2].outputs) == 0 if is_stripped else 1
 

--- a/tests/test_notebook.ipynb
+++ b/tests/test_notebook.ipynb
@@ -1,0 +1,504 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "6eb28cf1-16af-4bb5-9300-a6e5c38021cc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-06-06T00:31:13.074630Z",
+     "iopub.status.busy": "2025-06-06T00:31:13.074347Z",
+     "iopub.status.idle": "2025-06-06T00:31:13.080954Z",
+     "shell.execute_reply": "2025-06-06T00:31:13.080554Z",
+     "shell.execute_reply.started": "2025-06-06T00:31:13.074613Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from tqdm import tqdm\n",
+    "from IPython.display import display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "f3d6ed14-712b-4cf5-9c9f-8e24aa3d5102",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-06-06T00:31:13.272685Z",
+     "iopub.status.busy": "2025-06-06T00:31:13.272395Z",
+     "iopub.status.idle": "2025-06-06T00:31:13.281256Z",
+     "shell.execute_reply": "2025-06-06T00:31:13.280858Z",
+     "shell.execute_reply.started": "2025-06-06T00:31:13.272669Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "100%|██████████| 6/6 [00:00<00:00, 127100.12it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i in tqdm(range(6)):\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "b01a519c-3faf-49b4-a6a2-7fedab0f58c6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-06-06T00:31:13.433574Z",
+     "iopub.status.busy": "2025-06-06T00:31:13.433308Z",
+     "iopub.status.idle": "2025-06-06T00:31:13.443121Z",
+     "shell.execute_reply": "2025-06-06T00:31:13.442756Z",
+     "shell.execute_reply.started": "2025-06-06T00:31:13.433557Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4bd7f0934d2a436aa6936c1e51b0f136",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "  0%|          | 0/6 [00:02<?, ?it/s]\u001b[A\u001b[A\n"
+     ]
+    }
+   ],
+   "source": [
+    "display(widgets.Output())\n",
+    "pbar = tqdm(total=6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "153102e6-f553-4cae-91e2-635d960ba34f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-06-06T00:31:14.299038Z",
+     "iopub.status.busy": "2025-06-06T00:31:14.298772Z",
+     "iopub.status.idle": "2025-06-06T00:31:14.308332Z",
+     "shell.execute_reply": "2025-06-06T00:31:14.307968Z",
+     "shell.execute_reply.started": "2025-06-06T00:31:14.299021Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ffe259c84ed14eb5b874545be345840f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "two\n"
+     ]
+    }
+   ],
+   "source": [
+    "o = widgets.Output()\n",
+    "display(o)\n",
+    "with o:\n",
+    "    print('one')\n",
+    "print('two')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.2"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "0823d891f1ef441c8d0ef896fd79cbdb": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_e00abd0abe8441419eafe5fd0d33b08c",
+       "outputs": [
+        {
+         "name": "stdout",
+         "output_type": "stream",
+         "text": "hi\n"
+        }
+       ]
+      }
+     },
+     "08e20016e34042918fe2c6e6c31675d0": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_4d64234e1b8446f3af0bbbb51abe419a"
+      }
+     },
+     "0c8ff3b8a8824be686112a0f620c6ff1": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_6628c0b4e05a4708a148c9959c2c4709"
+      }
+     },
+     "1b094d42781e4715a703b116f7d7d0b0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1c8abf85952d43aa88732ce69bef1339": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1f21551e63474ecd92e5049e86a7e08f": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_1c8abf85952d43aa88732ce69bef1339"
+      }
+     },
+     "21cd27ae29884ba4b8e8bbc53809603f": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_1b094d42781e4715a703b116f7d7d0b0"
+      }
+     },
+     "230a9ab29a5744c0b3d3a2c7864ca57f": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_de34964ccad1439fabd7a87e755f4730",
+       "outputs": [
+        {
+         "name": "stdout",
+         "output_type": "stream",
+         "text": "one\n"
+        }
+       ]
+      }
+     },
+     "338af0c98175419ca9f1e06e5cc99265": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "33c4f34c93aa40fd9d1f20ce6689c96c": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_da4425037c8c495aa87724633ece0c7d"
+      }
+     },
+     "381747e4a9614761ac2b99daee87656b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3ba7cb48ab214e6fa58eb7481d02f35e": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_455e3050bdaf4b25899929008106f4b5"
+      }
+     },
+     "411e9f3a672b4428a9d5cd492cf922ab": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "447173a683ec4438a2e7afb696b18556": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_e175151117554cd19ebd9dcbfbea20fd"
+      }
+     },
+     "455e3050bdaf4b25899929008106f4b5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4bd7f0934d2a436aa6936c1e51b0f136": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_381747e4a9614761ac2b99daee87656b"
+      }
+     },
+     "4d64234e1b8446f3af0bbbb51abe419a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4ffed5c5b55b4a7bb09121efbd9732c2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "52152d3db06847849eda583e805b5cd2": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_338af0c98175419ca9f1e06e5cc99265",
+       "outputs": [
+        {
+         "name": "stdout",
+         "output_type": "stream",
+         "text": "one\n"
+        }
+       ]
+      }
+     },
+     "5792625c8b494314abf79473654d8a9c": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_dedf5c22489d4f35817d74bbc62f63bd"
+      }
+     },
+     "58666d4da46248e49cc0ea851cc1cda1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "58ddec787edb4fa6bd0329650381c25c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5ae36e821c614897a26573647d9e5cb4": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_58666d4da46248e49cc0ea851cc1cda1"
+      }
+     },
+     "6628c0b4e05a4708a148c9959c2c4709": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "687350627ed64455b0d85163bf5887b2": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_95864d9262c44bbb92c1007b7d61a9f1",
+       "outputs": [
+        {
+         "name": "stdout",
+         "output_type": "stream",
+         "text": "hi\n"
+        }
+       ]
+      }
+     },
+     "68782e950ea14610ab274a354279b361": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_7563aa9b8aaa4bbf9a5e14757102ff36"
+      }
+     },
+     "7000eb1e88b84f33bb837718c4b89464": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7563aa9b8aaa4bbf9a5e14757102ff36": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7fa3edfe8150414b8b22dc50f7676a8d": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_7000eb1e88b84f33bb837718c4b89464"
+      }
+     },
+     "82fd829e753e478ab91553d586a3da43": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_4ffed5c5b55b4a7bb09121efbd9732c2",
+       "outputs": [
+        {
+         "name": "stdout",
+         "output_type": "stream",
+         "text": "one\n"
+        }
+       ]
+      }
+     },
+     "95864d9262c44bbb92c1007b7d61a9f1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c21b7256f7b9411bb12bd8c04030b556": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "da4425037c8c495aa87724633ece0c7d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "da729f751f774d008730e4a3e3954ce7": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_58ddec787edb4fa6bd0329650381c25c"
+      }
+     },
+     "dd24a360616e4754b6127de5fa6f6d2f": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_e47a41051aa0434bb57daff528e8d3f6"
+      }
+     },
+     "de34964ccad1439fabd7a87e755f4730": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dedf5c22489d4f35817d74bbc62f63bd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e00abd0abe8441419eafe5fd0d33b08c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e175151117554cd19ebd9dcbfbea20fd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e47a41051aa0434bb57daff528e8d3f6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f38f7e86b1154f61921d5b8f2c90a6d9": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_c21b7256f7b9411bb12bd8c04030b556"
+      }
+     },
+     "ffe259c84ed14eb5b874545be345840f": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_411e9f3a672b4428a9d5cd492cf922ab",
+       "outputs": [
+        {
+         "name": "stdout",
+         "output_type": "stream",
+         "text": "one\n"
+        }
+       ]
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds a `widget_regex` parameter to `stripout` to be matched against cells with widget output. Cells with `text/plain` output that matches the regex will be stripped. If no argument is specified for `widget_regex`, or `widget_regex=None`, "^Output();?$" will be used as the default regex.

Note that the `pyo3` version was bumped to `0.25.0` to make use of of `#[pyo3(signature = ...)]` for setting default value of `widget_regex`.

Closes #20.

Blocked by #23.