### PR TITLE
Fix: Enabling strip-regex parameter through config file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -200,7 +200,7 @@ fn main() -> Result<(), String> {
     let mut keep_output = false;
     let mut keep_count = false;
     let mut drop_empty_cells = false;
-    let mut strip_regex: Option<String> = None;
+    let mut strip_regex: Option<String> = args.strip_regex;
 
     let mut extra_keys: Vec<String> = vec![];
     for key in DEFAULT_EXTRA_KEYS {
@@ -213,9 +213,7 @@ fn main() -> Result<(), String> {
             keep_output = nbstripout_fast.keep_output.unwrap_or(keep_output);
             keep_count = nbstripout_fast.keep_count.unwrap_or(keep_count);
             drop_empty_cells = nbstripout_fast.drop_empty_cells.unwrap_or(drop_empty_cells);
-            if let Some(config_strip_regex) = nbstripout_fast.strip_regex {
-                strip_regex = Some(config_strip_regex);
-            }
+            strip_regex = strip_regex.or(nbstripout_fast.strip_regex);
             if let Some(config_extra_keys) = nbstripout_fast.extra_keys {
                 for key in config_extra_keys {
                     extra_keys.push(key.to_string());
@@ -261,9 +259,6 @@ fn main() -> Result<(), String> {
     }
     if args.drop_empty_cells {
         drop_empty_cells = true;
-    }
-    if let Some(cli_strip_regex) = args.strip_regex {
-        strip_regex = Some(cli_strip_regex);
     }
 
     log::debug!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,7 @@ struct NBConfigNBStripOutFastConfig {
     drop_empty_cells: Option<bool>,
     extra_keys: Option<Vec<String>>,
     keep_keys: Option<Vec<String>>,
+    strip_regex: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -199,7 +200,7 @@ fn main() -> Result<(), String> {
     let mut keep_output = false;
     let mut keep_count = false;
     let mut drop_empty_cells = false;
-    let strip_regex = args.strip_regex.as_deref();
+    let mut strip_regex: Option<String> = None;
 
     let mut extra_keys: Vec<String> = vec![];
     for key in DEFAULT_EXTRA_KEYS {
@@ -212,6 +213,9 @@ fn main() -> Result<(), String> {
             keep_output = nbstripout_fast.keep_output.unwrap_or(keep_output);
             keep_count = nbstripout_fast.keep_count.unwrap_or(keep_count);
             drop_empty_cells = nbstripout_fast.drop_empty_cells.unwrap_or(drop_empty_cells);
+            if let Some(config_strip_regex) = nbstripout_fast.strip_regex {
+                strip_regex = Some(config_strip_regex);
+            }
             if let Some(config_extra_keys) = nbstripout_fast.extra_keys {
                 for key in config_extra_keys {
                     extra_keys.push(key.to_string());
@@ -258,12 +262,16 @@ fn main() -> Result<(), String> {
     if args.drop_empty_cells {
         drop_empty_cells = true;
     }
+    if let Some(cli_strip_regex) = args.strip_regex {
+        strip_regex = Some(cli_strip_regex);
+    }
 
     log::debug!(
-        "Using keep_count: {} keep_output: {} drop_empty_cells: {} extra_keys: {:?} ",
+        "Using keep_count: {} keep_output: {} drop_empty_cells: {} strip_regex: {:?} extra_keys: {:?} ",
         keep_count,
         keep_output,
         drop_empty_cells,
+        strip_regex,
         extra_keys
     );
     if args.files.is_empty() {
@@ -275,7 +283,7 @@ fn main() -> Result<(), String> {
             keep_count,
             &extra_keys,
             drop_empty_cells,
-            strip_regex,
+            strip_regex.as_deref(),
             None,
         )?;
     } else {
@@ -296,7 +304,7 @@ fn main() -> Result<(), String> {
                 keep_count,
                 &extra_keys,
                 drop_empty_cells,
-                strip_regex,
+                strip_regex.as_deref(),
                 output_file,
             )?;
         }

--- a/src/stripoutlib.rs
+++ b/src/stripoutlib.rs
@@ -166,11 +166,12 @@ pub fn strip_output(
     strip_regex: Option<&str>,
 ) -> Result<bool, String> {
     log::debug!(
-        "keep-output: {}, keep-count: {}, extra-keys: {:?}, drop-empty-cells: {}",
+        "keep-output: {}, keep-count: {}, extra-keys: {:?}, drop-empty-cells: {}, strip-regex: {:?}",
         keep_output,
         keep_count,
         extra_keys,
-        drop_empty_cells
+        drop_empty_cells,
+        strip_regex
     );
     let mut metadata_keys = Vec::<String>::new();
     let mut cell_keys = Vec::<String>::new();


### PR DESCRIPTION
Detailed explanation:
- strip-regex parameter was not supported through config file
- Add support for strip-regex to be read from config file
- Testing done with the existing test cases
- CLI argument takes precedence over config file