### PR TITLE
Chore: Add BSD-3-Clause license classifier to PyPI metadata (Fix Issue #27)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers=[
     "Environment :: Other Environment",
     "Framework :: IPython",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 author="Marc Udoff"
 author_email="marc.udoff@deshaw.com"
 url="https://github.com/deshaw/nbstripout-fast"
-license = {text = "BSD-3-Clause"}
+license = {file = "LICENSE.txt"}
 requires_python=">=3.9"
 setup_requires=[
     "pytest-runner",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 author="Marc Udoff"
 author_email="marc.udoff@deshaw.com"
 url="https://github.com/deshaw/nbstripout-fast"
+license = {text = "BSD-3-Clause"}
 requires_python=">=3.9"
 setup_requires=[
     "pytest-runner",
@@ -22,6 +23,7 @@ classifiers=[
     "Environment :: Other Environment",
     "Framework :: IPython",
     "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Adds the appropriate BSD-3-Clause license classifier so the project license appears correctly in PyPI metadata.