### PR TITLE
Fix invalid notebooks by keeping execution_count as null (Issue #19)

### DIFF
--- a/src/stripoutlib.rs
+++ b/src/stripoutlib.rs
@@ -278,7 +278,11 @@ pub fn strip_output(
                 if !keep_count {
                     for output in outputs {
                         let obj = output.as_object_mut().expect("Output should be an object");
-                        obj.remove("execution_count");
+
+                        // Null (don't delete) execution_count to satisfy nbformat schema.
+                        if obj.contains_key("execution_count") {
+                            obj.insert("execution_count".to_string(), json!(null));
+                        }
                     }
                 }
             }

--- a/tests/test_nbstripout_fast.py
+++ b/tests/test_nbstripout_fast.py
@@ -95,6 +95,10 @@ def test_keep_output():
         cell.get("execution_count", None) is None for cell in stripped_notebook.cells
     )
     assert len(stripped_notebook.cells[-3]["outputs"]) == 1
+    
+    out = stripped_notebook.cells[-3]["outputs"][0]
+    assert out["output_type"] == "execute_result"
+    assert "execution_count" in out and out["execution_count"] is None
 
 
 def test_keep_count():


### PR DESCRIPTION
Fixes Issue #19 

When running nbstripout-fast with `--keep-output` and without `--keep-count`, the `execution_count` field was being removed. `execution_count` is required by nbformat, so we got invalid notebooks.

The PR sets `execution_count` to null instead of deleting it, keeping valid notebook structure.

### Validation

```bash
cargo run -- --keep-output -t tests/test_notebook.ipynb > /tmp/stripped.ipynb

python3 - <<'EOF'
import nbformat
from nbformat.validator import validate
nb = nbformat.read('/tmp/stripped.ipynb', as_version=4)
validate(nb)
print("OK")
EOF