### PR TITLE
Fix PEP 621 issue in pyproject.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nbstripout-fast"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ classifiers=[
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
+dynamic = ['version']
+
 [project.urls]
 homepage = "https://github.com/deshaw/nbstripout-fast"
 


### PR DESCRIPTION
This package has its version dynamically set by the maturin backend. If you do not set `version` to be dynamic, strict package managers will not be happy.

Example from `uv`

```
root@me/tmp/nbstripout-fast# uv build .
Building source distribution...
  × Failed to build `/tmp/nbstripout-fast`
  ├─▶ Failed to parse: `pyproject.toml`
  ╰─▶ TOML parse error at line 5, column 1
        |
      5 | [project]
        | ^^^^^^^^^
      `pyproject.toml` is using the `[project]` table, but the 
```

Example of other projects doing the same https://github.com/pydantic/pydantic-core/blob/main/pyproject.toml#L43
See also in docs https://www.maturin.rs/metadata.html#dynamic-metadata

Without this change: error like above
With this change: `uv build .` builds successfully

I have signed the CLA for my username `markjm`