### PR TITLE
update wheel builder to also build arm wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -52,17 +52,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, windows, macos]
+        os: [ubuntu, ubuntu-arm, windows, macos]
         python-version: ['cp312', 'cp311', 'cp310', 'cp39']
         include:
           - os: ubuntu
             platform: linux
             pip_cache: ~/.cache/pip
+          - os: ubuntu-arm
+            platform: linux-arm
+            pip_cache: ~/.cache/pip
+            runs_on: ubuntu-24.04-arm
           - os: windows
             ls: dir
             pip_cache: ~\AppData\Local\pip\Cache
 
-    runs-on: ${{ format('{0}-latest', matrix.os) }}
+    runs-on: ${{ matrix.runs_on || format('{0}-latest', matrix.os) }}
     steps:
     - name: Check out the repo
       uses: actions/checkout@v4


### PR DESCRIPTION
According to https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories, there are no `latest` tags for arm, so need to just directly include the arm label name.

As a non-participant of this repo, i dont really have permissions or the ability to actually run and validate this change, but figured id put it up in case there is interest.

Note this is related to #30 because `uv` wont try to build a dependency if a wheel is available, so we can also just make it available

I have signed the CLA