### PR TITLE
Update the CI action versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up rust toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -18,9 +18,9 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - name: Set up python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Install python dependencies
       run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up rust toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -24,7 +24,7 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - name: Set up python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -41,7 +41,7 @@ jobs:
         twine check wheelhouse/*
 
     - name: Upload sdist
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: wheels-sdist
         path: ./wheelhouse/*.tar.gz
@@ -65,10 +65,10 @@ jobs:
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -93,7 +93,7 @@ jobs:
         rustup target add i686-pc-windows-msvc
 
     - name: Build ${{ matrix.platform || matrix.os }} binaries
-      uses: pypa/cibuildwheel@v2.23.1
+      uses: pypa/cibuildwheel@v3.4.0
       env:
         CIBW_BUILD: '${{ matrix.python-version }}-*'
         # rust doesn't seem to be available for musl linux on i686
@@ -116,7 +116,7 @@ jobs:
         twine check wheelhouse/*
 
     - name: Upload wheels
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: wheels-${{ matrix.os }}-${{ matrix.python-version }}
         path: ./wheelhouse/*.whl
@@ -133,7 +133,7 @@ jobs:
       id-token: write
     steps:
       - name: Retrieve wheels and sdist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: wheels-*
           merge-multiple: true
@@ -144,6 +144,6 @@ jobs:
           ls -lAs wheels/
 
       - name: Upload to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.12
+        uses: pypa/gh-action-pypi-publish@release/v1.13
         with:
           packages_dir: wheels/


### PR DESCRIPTION
This PR updates the CI action versions to the most recent stable versions. According to https://github.com/pypa/cibuildwheel/issues/2768#issuecomment-4038782856, bumping the cibuildwheel action should resolve the issue with recent PRs getting rate limited when building wheels and then failing as a result.

I've also bumped the python version used to test to 3.12, to match the environment used for building wheels.