### PR TITLE
Add a verbose flag to debug wheel publishing

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -151,3 +151,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1.13
         with:
           packages_dir: wheels/
+          verbose: true


### PR DESCRIPTION
This PR adds a verbose flag to the `gh-action-pypi-publish` so we can debug why the last publish attempt failed.