### PR TITLE
Handle builds against various python versions with cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,12 +48,11 @@ jobs:
 
   build_wheels:
     name: >
-      build ${{ matrix.python-version }} on ${{ matrix.platform || matrix.os }}
+      build ${{ matrix.platform || matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu, ubuntu-arm, windows, macos]
-        python-version: ['cp312', 'cp311', 'cp310', 'cp39']
         include:
           - os: ubuntu
             platform: linux
@@ -99,9 +98,9 @@ jobs:
     - name: Build ${{ matrix.platform || matrix.os }} binaries
       uses: pypa/cibuildwheel@v3.4.0
       env:
-        CIBW_BUILD: '${{ matrix.python-version }}-*'
+        CIBW_BUILD: 'cp*'
         # rust doesn't seem to be available for musl linux on i686
-        CIBW_SKIP: '*-musllinux_i686'
+        CIBW_SKIP: '*-musllinux_i686 cp38* cp313* cp314*'
         # we build for matrix.arch (only exists on macos), else 'auto'
         CIBW_ARCHS: 'auto'
         CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH" CARGO_TERM_COLOR="always"'
@@ -122,7 +121,7 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v7
       with:
-        name: wheels-${{ matrix.os }}-${{ matrix.python-version }}
+        name: wheels-${{ matrix.os }}
         path: ./wheelhouse/*.whl
 
   upload_to_pypi:


### PR DESCRIPTION
This PR fixes [an issue with uploading our wheels to PyPI](https://github.com/deshaw/nbstripout-fast/actions/runs/23259007536).

I'm really not sure why this change works, but I noticed that

1. We were splitting the task of building against different versions of python across different CI jobs using a matrix
2. cibuildwheel can handle building against multiple versions of python just fine
3. The wheels built here contain pure rust code (see `maturin.bindings = 'bin'` in `pyproject.toml`). As a result the wheels are compatible with all python versions
4. When I made cibuildwheel build the various python versions, [the job](https://github.com/peytondmurray/nbstripout-fast/actions/runs/23331812219) was able to [successfully](https://github.com/peytondmurray/nbstripout-fast/actions/runs/23331812219/job/67865354827) upload [to test.pypi.org](https://test.pypi.org/project/nbso/). Furthermore, cibuildwheel doesn't bother building wheels if the ones it has already built are already compatible across versions, so we're really not losing much here in the way of build time if we compare to splitting python versions across a CI matrix. In fact we are doing considerably less work overall (since those "duplicate" build jobs get skipped by cibuildwheel), though it probably is a tiny bit slower.

Again, I'm not sure why PyPI is rejecting our wheels if we build them one-by-one, but given that this is a perfectly valid way of building these, I'm fine with this change.