### PR TITLE
Fix: check --ignore-git-nb-config flag when loading repo config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -194,8 +194,12 @@ fn process_file(
 
 fn main() -> Result<(), String> {
     env_logger::init();
-    let config = find_nbconfig()?;
     let args = Cli::parse();
+    let config = if args.ignore_git_nb_config {
+        None
+    } else {
+        find_nbconfig()?
+    };
 
     let mut keep_output = false;
     let mut keep_count = false;


### PR DESCRIPTION
### Issue
--ignore-git-nb-config flag was initialized but was never being checked for when loading .git-nbconfig.yaml. 

### Fix
Parsed CLI args before loading repo config and skip loading .git-nbconfig.yaml if flag is set.

### Testing
Reproduced with a temp repo containing .git-nbconfig.yaml (keep_output: true). Output was stripped when flag was set.