### PR TITLE
Make `pyproject.toml` PEP639 compliant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,10 @@ readme = "README.md"
 author="Marc Udoff"
 author_email="marc.udoff@deshaw.com"
 url="https://github.com/deshaw/nbstripout-fast"
-license = {file = "LICENSE.txt"}
+license = "BSD-3-Clause"
+license-files = [
+    "LICENSE.txt"
+]
 requires_python=">=3.9"
 setup_requires=[
     "pytest-runner",


### PR DESCRIPTION
Follow on from #28 - according to https://packaging.python.org/en/latest/specifications/pyproject-toml/#license the `license` field needs to be a string, and `license-files` is where we should be putting license file paths. After discussing with colleagues, it seems PEP639-compliance will result in the license expression being shown on the PyPI page for this project. Closes #27.