### PR TITLE
Pin the github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,22 +3,26 @@ name: Run tests
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   run_tests:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
 
     - name: Set up rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      run: rustup toolchain install stable
 
     - name: Set up rust cache
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
     - name: Set up python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: '3.12'
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,6 +6,8 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -15,16 +17,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
 
     - name: Set up rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      run: rustup toolchain install stable
 
     - name: Set up rust cache
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
     - name: Set up python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: '3.12'
 
@@ -41,7 +45,7 @@ jobs:
         twine check wheelhouse/*
 
     - name: Upload sdist
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: wheels-sdist
         path: ./wheelhouse/*.tar.gz
@@ -68,20 +72,22 @@ jobs:
     runs-on: ${{ matrix.runs_on || format('{0}-latest', matrix.os) }}
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
 
     - name: Set up python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: '3.12'
 
     - if: matrix.os == 'macos' || matrix.os == 'windows'
       name: Set up rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      run: rustup toolchain install stable
 
     - if: matrix.os == 'macos' || matrix.os == 'windows'
       name: Set up rust cache
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
     # Set up rust toolchain on mac os and windows (linux containers handled below)
     - if: matrix.os == 'macos'
@@ -96,7 +102,7 @@ jobs:
         rustup target add i686-pc-windows-msvc
 
     - name: Build ${{ matrix.platform || matrix.os }} binaries
-      uses: pypa/cibuildwheel@v3.4.0
+      uses: pypa/cibuildwheel@ee02a1537ce3071a004a6b08c41e72f0fdc42d9a # v3.4.0
       env:
         CIBW_BUILD: 'cp*'
         # rust doesn't seem to be available for musl linux on i686
@@ -119,7 +125,7 @@ jobs:
         twine check wheelhouse/*
 
     - name: Upload wheels
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: wheels-${{ matrix.os }}
         path: ./wheelhouse/*.whl
@@ -136,7 +142,7 @@ jobs:
       id-token: write
     steps:
       - name: Retrieve wheels and sdist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: wheels-*
           merge-multiple: true
@@ -147,7 +153,7 @@ jobs:
           ls -lAs wheels/
 
       - name: Upload to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.13
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1.13
         with:
           packages_dir: wheels/
           verbose: true


### PR DESCRIPTION
This PR addresses a number of security-related issues with the github actions. All issues fixed here were found by [zizmor](https://docs.zizmor.sh/). Later on I'll make a PR to make zizmor audit our actions during PRs so that we avoid writing insecure actions in the future.

Changes:

- Explicit permissions were added to actions. The one place where we require elevated permissions scopes those permissions to ONLY the job that uses them
- All actions are now pinned to commit hashes to prevent malicious mutable-reference manipulation. These commit hashes were found using `zizmor --gh-token $(gh auth token) --fix=all ./` to automatically get the right commit hash for each tag.
- A few uses of `dtolnay/rust-toolchain` have been removed. Github runners should have rustup installed already, so we instead just install the toolchain we want using that